### PR TITLE
feat: delete empty gratitudes via blur

### DIFF
--- a/src/components/TheList.vue
+++ b/src/components/TheList.vue
@@ -10,6 +10,7 @@
             :name="singleNote"
             ref="textarea"
             @input="(event) => handleEditingGratitude(gratitude.id, event.target.value)"
+            @blur="handleDeletingGratitude(gratitude.id, gratitude.text)"
           ></textarea>
           <!-- <button >speichern</button> -->
         </label>
@@ -21,7 +22,7 @@
         <label>
           <textarea
             v-model="text"
-            placeholder="Add a new gratitude..."
+            placeholder="Heute bin ich dankbar für..."
             @input="resize($event)"
             @keydown.enter.exact.prevent="handleNewGratitude()"
             @blur="handleNewGratitude()"
@@ -64,9 +65,15 @@ export default {
       }
     },
     handleEditingGratitude(id, text) {
-      console.log('id :' + id)
-      console.log('text: ' + text)
       this.gratitudesStore.editGratitude(id, text)
+    },
+    handleDeletingGratitude(id, text) {
+      const store = this.gratitudesStore
+      if (text === '') {
+        store.deleteGratitude(id)
+      } else {
+        return
+      }
     },
     resize(event) {
       const element = event.target

--- a/src/stores/gratitudes.js
+++ b/src/stores/gratitudes.js
@@ -31,10 +31,10 @@ export const useGratitudesStore = defineStore('gratitudes', {
     editGratitude(id, text) {
       const toBeEdited = this.gratitudes.find((gratitude) => gratitude.id === id)
       toBeEdited.text = text
-      console.log(toBeEdited)
     },
     deleteGratitude(id) {
-      const toBeDeleted = this.gratitude.find((gratitude) => gratitude.id === id)
+      const toBeDeleted = this.gratitudes.indexOf((gratitude) => gratitude.id === id)
+      this.gratitudes.splice(toBeDeleted, 1)
     }
   }
 })


### PR DESCRIPTION
closes #24 
existing gratitudes can now be deleted by deleting the text and clicking out of the textarea.